### PR TITLE
隐藏免流量特权 bug修复

### DIFF
--- a/app/src/main/java/me/zpp0196/qqsimple/hook/SidebarHook.java
+++ b/app/src/main/java/me/zpp0196/qqsimple/hook/SidebarHook.java
@@ -93,7 +93,7 @@ public class SidebarHook extends BaseHook {
         });
 
         // 免流量特权
-        findAndHookMethod(QQSettingMe, "P", replaceNull("hide_sidebar_kingCard"));
+        findAndHookMethod(QQSettingMe, "Q", replaceNull("hide_sidebar_kingCard"));
     }
 
     private void hideViews(XC_MethodHook.MethodHookParam param) {


### PR DESCRIPTION
修复免流量特权不能隐藏问题

估计是QQ在新版本编译的时候，混淆插件重新混淆了P方法变Q方法了。